### PR TITLE
Add option to email the default queue of a Business Unit

### DIFF
--- a/LAT.WorkflowUtilities.Email.Tests/EmailBusinessUnitQueueTests.cs
+++ b/LAT.WorkflowUtilities.Email.Tests/EmailBusinessUnitQueueTests.cs
@@ -1,0 +1,954 @@
+﻿using FakeXrmEasy;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Xrm.Sdk;
+using System;
+using System.Collections.Generic;
+
+namespace LAT.WorkflowUtilities.Email.Tests
+{
+    [TestClass]
+    public class EmailBusinessUnitQueueTests
+    {
+        #region Test Initialization and Cleanup
+        // Use ClassInitialize to run code before running the first test in the class
+        [ClassInitialize()]
+        public static void ClassInitialize(TestContext testContext) { }
+
+        // Use ClassCleanup to run code after all tests in a class have run
+        [ClassCleanup()]
+        public static void ClassCleanup() { }
+
+        // Use TestInitialize to run code before running each test 
+        [TestInitialize()]
+        public void TestMethodInitialize() { }
+
+        // Use TestCleanup to run code after each test has run
+        [TestCleanup()]
+        public void TestMethodCleanup() { }
+        #endregion
+
+        [TestMethod]
+        public void EmailBusinessUnitQueue_Business_Unit_With_No_Existing_Default_Team()
+        {
+            //Arrange
+            XrmFakedWorkflowContext workflowContext = new XrmFakedWorkflowContext();
+
+            Guid id = Guid.NewGuid();
+            Entity email = new Entity("email")
+            {
+                Id = id,
+                ["activityid"] = id,
+                ["to"] = new EntityCollection()
+            };
+
+            Entity businessUnit = new Entity("businessunit")
+            {
+                Id = Guid.NewGuid()
+            };
+
+            Entity team = new Entity("team")
+            {
+                Id = Guid.NewGuid(),
+                ["isdefault"] = false,
+                ["businessunitid"] = businessUnit.Id
+            };
+
+            Entity systemUser1 = new Entity("systemuser")
+            {
+                Id = Guid.NewGuid(),
+                ["internalemailaddress"] = null,
+                ["isdisabled"] = false,
+                ["businessunitid"] = businessUnit.Id
+            };
+
+            Entity teammembership = new Entity("teammembership")
+            {
+                Id = Guid.NewGuid(),
+                ["teamid"] = team.Id,
+                ["systemuserid"] = systemUser1.Id
+            };
+
+            Entity queue = new Entity("queue")
+            {
+                Id = Guid.NewGuid(),
+                ["ownerid"] = team.Id,
+                ["owningteam"] = team.Id,
+                ["businessunitid"] = businessUnit.Id
+            };
+
+            // Relationship from team to its queue
+            team["queueid"] = queue.Id;
+
+            var inputs = new Dictionary<string, object>
+            {
+                { "EmailToSend", email.ToEntityReference() },
+                { "RecipientBusinessUnit", businessUnit.ToEntityReference() },
+                { "SendEmail", false }
+            };
+
+            XrmFakedContext xrmFakedContext = new XrmFakedContext();
+            xrmFakedContext.Initialize(new List<Entity> { email, businessUnit, team, systemUser1, teammembership, queue });
+
+            const int expected = 0;
+
+            //Act
+            var result = xrmFakedContext.ExecuteCodeActivity<EmailBusinessUnitQueue>(workflowContext, inputs);
+
+            //Assert
+            Assert.AreEqual(expected, result["UsersAdded"]);
+        }
+
+        [TestMethod]
+        public void EmailBusinessUnitQueue_Business_Unit_With_Default_Team_But_No_Queues()
+        {
+            //Arrange
+            XrmFakedWorkflowContext workflowContext = new XrmFakedWorkflowContext();
+
+            Guid id = Guid.NewGuid();
+            Entity email = new Entity("email")
+            {
+                Id = id,
+                ["activityid"] = id,
+                ["to"] = new EntityCollection()
+            };
+
+            Entity businessUnit = new Entity("businessunit")
+            {
+                Id = Guid.NewGuid()
+            };
+
+            Entity team = new Entity("team")
+            {
+                Id = Guid.NewGuid(),
+                ["isdefault"] = true,
+                ["businessunitid"] = businessUnit.Id
+            };
+
+            Entity systemUser1 = new Entity("systemuser")
+            {
+                Id = Guid.NewGuid(),
+                ["internalemailaddress"] = null,
+                ["isdisabled"] = false,
+                ["businessunitid"] = businessUnit.Id
+            };
+
+            Entity teammembership = new Entity("teammembership")
+            {
+                Id = Guid.NewGuid(),
+                ["teamid"] = team.Id,
+                ["systemuserid"] = systemUser1.Id
+            };
+
+            var inputs = new Dictionary<string, object>
+            {
+                { "EmailToSend", email.ToEntityReference() },
+                { "RecipientBusinessUnit", businessUnit.ToEntityReference() },
+                { "SendEmail", false }
+            };
+
+            XrmFakedContext xrmFakedContext = new XrmFakedContext();
+            xrmFakedContext.Initialize(new List<Entity> { email, businessUnit, team, systemUser1, teammembership });
+
+            const int expected = 0;
+
+            //Act
+            var result = xrmFakedContext.ExecuteCodeActivity<EmailBusinessUnitQueue>(workflowContext, inputs);
+
+            //Assert
+            Assert.AreEqual(expected, result["UsersAdded"]);
+        }
+
+        [TestMethod]
+        public void EmailBusinessUnitQueue_Business_Unit_With_1_Default_Team_And_Queue()
+        {
+            //Arrange
+            XrmFakedWorkflowContext workflowContext = new XrmFakedWorkflowContext();
+
+            Guid id = Guid.NewGuid();
+            Entity email = new Entity("email")
+            {
+                Id = id,
+                ["activityid"] = id,
+                ["to"] = new EntityCollection()
+            };
+
+            Entity businessUnit = new Entity("businessunit")
+            {
+                Id = Guid.NewGuid()
+            };
+
+            Entity team = new Entity("team")
+            {
+                Id = Guid.NewGuid(),
+                ["isdefault"] = true,
+                ["businessunitid"] = businessUnit.Id
+            };
+
+            Entity systemUser1 = new Entity("systemuser")
+            {
+                Id = Guid.NewGuid(),
+                ["internalemailaddress"] = null,
+                ["isdisabled"] = false,
+                ["businessunitid"] = businessUnit.Id
+            };
+
+            Entity teammembership = new Entity("teammembership")
+            {
+                Id = Guid.NewGuid(),
+                ["teamid"] = team.Id,
+                ["systemuserid"] = systemUser1.Id
+            };
+
+            Entity queue = new Entity("queue")
+            {
+                Id = Guid.NewGuid(),
+                ["ownerid"] = team.Id,
+                ["owningteam"] = team.Id,
+                ["businessunitid"] = businessUnit.Id,
+            };
+
+            // Relationship from team to its queue
+            team["queueid"] = queue.Id;
+
+            var inputs = new Dictionary<string, object>
+            {
+                { "EmailToSend", email.ToEntityReference() },
+                { "RecipientBusinessUnit", businessUnit.ToEntityReference() },
+                { "SendEmail", false }
+            };
+
+            XrmFakedContext xrmFakedContext = new XrmFakedContext();
+            xrmFakedContext.Initialize(new List<Entity> { email, businessUnit, team, systemUser1, teammembership, queue });
+
+            const int expected = 1;
+
+            //Act
+            var result = xrmFakedContext.ExecuteCodeActivity<EmailBusinessUnitQueue>(workflowContext, inputs);
+
+            //Assert
+            Assert.AreEqual(expected, result["UsersAdded"]);
+        }
+
+        [TestMethod]
+        public void EmailBusinessUnitQueue_Business_Unit_With_1_Default_Team_And_Queue_Existing_To()
+        {
+            //Arrange
+            XrmFakedWorkflowContext workflowContext = new XrmFakedWorkflowContext();
+
+            Guid id = Guid.NewGuid();
+            Entity email = new Entity("email")
+            {
+                Id = id,
+                ["activityid"] = id,
+                ["cc"] = new EntityCollection()
+            };
+
+            // Existing recipient
+            Guid id2 = Guid.NewGuid();
+            Entity activityParty = new Entity("activityparty")
+            {
+                Id = id2,
+                ["activitypartyid"] = id2,
+                ["activityid"] = new EntityReference("email", id),
+                ["partyid"] = new EntityReference("contact", Guid.NewGuid()),
+                ["participationtypemask"] = new OptionSetValue(2)
+            };
+
+            EntityCollection to = new EntityCollection();
+            to.Entities.Add(activityParty);
+            email["to"] = to;
+
+            Entity businessUnit = new Entity("businessunit")
+            {
+                Id = Guid.NewGuid()
+            };
+
+            Entity team = new Entity("team")
+            {
+                Id = Guid.NewGuid(),
+                ["isdefault"] = true,
+                ["businessunitid"] = businessUnit.Id
+            };
+
+            Entity systemUser1 = new Entity("systemuser")
+            {
+                Id = Guid.NewGuid(),
+                ["internalemailaddress"] = null,
+                ["isdisabled"] = false,
+                ["businessunitid"] = businessUnit.Id
+            };
+
+            Entity teammembership = new Entity("teammembership")
+            {
+                Id = Guid.NewGuid(),
+                ["teamid"] = team.Id,
+                ["systemuserid"] = systemUser1.Id
+            };
+
+            Entity queue = new Entity("queue")
+            {
+                Id = Guid.NewGuid(),
+                ["ownerid"] = team.Id,
+                ["owningteam"] = team.Id,
+                ["businessunitid"] = businessUnit.Id
+            };
+
+            // Relationship from team to its queue
+            team["queueid"] = queue.Id;
+
+            var inputs = new Dictionary<string, object>
+            {
+                { "EmailToSend", email.ToEntityReference() },
+                { "RecipientBusinessUnit", businessUnit.ToEntityReference() },
+                { "SendEmail", false }
+            };
+
+            XrmFakedContext xrmFakedContext = new XrmFakedContext();
+            xrmFakedContext.Initialize(new List<Entity> { email, businessUnit, team, systemUser1, teammembership, queue, activityParty });
+
+            const int expected = 2;
+
+            //Act
+            var result = xrmFakedContext.ExecuteCodeActivity<EmailBusinessUnitQueue>(workflowContext, inputs);
+
+            //Assert
+            Assert.AreEqual(expected, result["UsersAdded"]);
+        }
+
+        [TestMethod]
+        public void EmailBusinessUnitQueue_Business_Unit_With_1_Default_Team_And_Queue_Existing_CC()
+        {
+            //Arrange
+            XrmFakedWorkflowContext workflowContext = new XrmFakedWorkflowContext();
+
+            Guid id = Guid.NewGuid();
+            Entity email = new Entity("email")
+            {
+                Id = id,
+                ["activityid"] = id,
+                ["to"] = new EntityCollection()
+            };
+
+            // Existing recipient
+            Guid id2 = Guid.NewGuid();
+            Entity activityParty = new Entity("activityparty")
+            {
+                Id = id2,
+                ["activitypartyid"] = id2,
+                ["activityid"] = new EntityReference("email", id),
+                ["partyid"] = new EntityReference("contact", Guid.NewGuid()),
+                ["participationtypemask"] = new OptionSetValue(2)
+            };
+
+            EntityCollection to = new EntityCollection();
+            to.Entities.Add(activityParty);
+            email["cc"] = to;
+
+            Entity businessUnit = new Entity("businessunit")
+            {
+                Id = Guid.NewGuid()
+            };
+
+            Entity team = new Entity("team")
+            {
+                Id = Guid.NewGuid(),
+                ["isdefault"] = true,
+                ["businessunitid"] = businessUnit.Id
+            };
+
+            Entity systemUser1 = new Entity("systemuser")
+            {
+                Id = Guid.NewGuid(),
+                ["internalemailaddress"] = null,
+                ["isdisabled"] = false,
+                ["businessunitid"] = businessUnit.Id
+            };
+
+            Entity teammembership = new Entity("teammembership")
+            {
+                Id = Guid.NewGuid(),
+                ["teamid"] = team.Id,
+                ["systemuserid"] = systemUser1.Id
+            };
+
+            Entity queue = new Entity("queue")
+            {
+                Id = Guid.NewGuid(),
+                ["ownerid"] = team.Id,
+                ["owningteam"] = team.Id,
+                ["businessunitid"] = businessUnit.Id
+            };
+
+            // Relationship from team to its queue
+            team["queueid"] = queue.Id;
+
+            var inputs = new Dictionary<string, object>
+            {
+                { "EmailToSend", email.ToEntityReference() },
+                { "RecipientBusinessUnit", businessUnit.ToEntityReference() },
+                { "SendEmail", false }
+            };
+
+            XrmFakedContext xrmFakedContext = new XrmFakedContext();
+            xrmFakedContext.Initialize(new List<Entity> { email, businessUnit, team, systemUser1, teammembership, queue, activityParty });
+
+            const int expected = 2;
+
+            //Act
+            var result = xrmFakedContext.ExecuteCodeActivity<CcBusinessUnitQueue>(workflowContext, inputs);
+
+            //Assert
+            Assert.AreEqual(expected, result["UsersAdded"]);
+        }
+
+        [TestMethod]
+        public void EmailBusinessUnitQueue_Business_Unit_With_1_Default_Team_And_2_Queues()
+        {
+            //Arrange
+            XrmFakedWorkflowContext workflowContext = new XrmFakedWorkflowContext();
+
+            Guid id = Guid.NewGuid();
+            Entity email = new Entity("email")
+            {
+                Id = id,
+                ["activityid"] = id,
+                ["to"] = new EntityCollection()
+            };
+
+            Entity businessUnit = new Entity("businessunit")
+            {
+                Id = Guid.NewGuid()
+            };
+
+            Entity team = new Entity("team")
+            {
+                Id = Guid.NewGuid(),
+                ["isdefault"] = true,
+                ["businessunitid"] = businessUnit.Id
+            };
+
+            Entity systemUser1 = new Entity("systemuser")
+            {
+                Id = Guid.NewGuid(),
+                ["internalemailaddress"] = null,
+                ["isdisabled"] = false,
+                ["businessunitid"] = businessUnit.Id
+            };
+
+            Entity teammembership = new Entity("teammembership")
+            {
+                Id = Guid.NewGuid(),
+                ["teamid"] = team.Id,
+                ["systemuserid"] = systemUser1.Id
+            };
+
+            Entity queue1 = new Entity("queue")
+            {
+                Id = Guid.NewGuid(),
+                ["ownerid"] = team.Id,
+                ["owningteam"] = team.Id,
+                ["businessunitid"] = businessUnit.Id
+            };
+
+            // Relationship from team to its queue
+            team["queueid"] = queue1.Id;
+
+            // Second queue, owned by the tean but not the default queue
+            Entity queue2 = new Entity("queue")
+            {
+                Id = Guid.NewGuid(),
+                ["ownerid"] = team.Id,
+                ["owningteam"] = team.Id,
+                ["businessunitid"] = businessUnit.Id
+            };
+
+            var inputs = new Dictionary<string, object>
+            {
+                { "EmailToSend", email.ToEntityReference() },
+                { "RecipientBusinessUnit", businessUnit.ToEntityReference() },
+                { "SendEmail", false }
+            };
+
+            XrmFakedContext xrmFakedContext = new XrmFakedContext();
+            xrmFakedContext.Initialize(new List<Entity> { email, businessUnit, team, systemUser1, teammembership, queue1, queue2 });
+
+            const int expected = 1;
+
+            //Act
+            var result = xrmFakedContext.ExecuteCodeActivity<EmailBusinessUnitQueue>(workflowContext, inputs);
+
+            //Assert
+            Assert.AreEqual(expected, result["UsersAdded"]);
+        }
+
+        [TestMethod]
+        public void EmailBusinessUnitQueue_Business_Unit_With_2_Teams_And_2_Queues_Each()
+        {
+            //Arrange
+            XrmFakedWorkflowContext workflowContext = new XrmFakedWorkflowContext();
+
+            Guid id = Guid.NewGuid();
+            Entity email = new Entity("email")
+            {
+                Id = id,
+                ["activityid"] = id,
+                ["to"] = new EntityCollection()
+            };
+
+            Entity businessUnit = new Entity("businessunit")
+            {
+                Id = Guid.NewGuid()
+            };
+
+            Entity team1 = new Entity("team")
+            {
+                Id = Guid.NewGuid(),
+                ["isdefault"] = true,
+                ["businessunitid"] = businessUnit.Id
+            };
+
+            Entity systemUser1 = new Entity("systemuser")
+            {
+                Id = Guid.NewGuid(),
+                ["internalemailaddress"] = null,
+                ["isdisabled"] = false,
+                ["businessunitid"] = businessUnit.Id
+            };
+
+            Entity teammembership1 = new Entity("teammembership")
+            {
+                Id = Guid.NewGuid(),
+                ["teamid"] = team1.Id,
+                ["systemuserid"] = systemUser1.Id
+            };
+
+            Entity queue1 = new Entity("queue")
+            {
+                Id = Guid.NewGuid(),
+                ["ownerid"] = team1.Id,
+                ["owningteam"] = team1.Id,
+                ["businessunitid"] = businessUnit.Id
+            };
+
+            // Relationship from team to its queue
+            team1["queueid"] = queue1.Id;
+
+            // Second team can't be the default
+            Entity team2 = new Entity("team")
+            {
+                Id = Guid.NewGuid(),
+                ["isdefault"] = false,
+                ["businessunitid"] = businessUnit.Id
+            };
+
+            Entity systemUser2 = new Entity("systemuser")
+            {
+                Id = Guid.NewGuid(),
+                ["internalemailaddress"] = null,
+                ["isdisabled"] = false,
+                ["businessunitid"] = businessUnit.Id
+            };
+
+            Entity teammembership2 = new Entity("teammembership")
+            {
+                Id = Guid.NewGuid(),
+                ["teamid"] = team2.Id,
+                ["systemuserid"] = systemUser2.Id
+            };
+
+            Entity queue2 = new Entity("queue")
+            {
+                Id = Guid.NewGuid(),
+                ["ownerid"] = team2.Id,
+                ["owningteam"] = team2.Id,
+                ["businessunitid"] = businessUnit.Id
+            };
+
+            // Relationship from team to its queue
+            team2["queueid"] = queue2.Id;
+
+            var inputs = new Dictionary<string, object>
+            {
+                { "EmailToSend", email.ToEntityReference() },
+                { "RecipientBusinessUnit", businessUnit.ToEntityReference() },
+                { "SendEmail", false }
+            };
+
+            XrmFakedContext xrmFakedContext = new XrmFakedContext();
+            xrmFakedContext.Initialize(new List<Entity> { email, businessUnit, team1, systemUser1, teammembership1, queue1, team2, systemUser2, teammembership2, queue2 });
+
+            const int expected = 1; // Just the default team should be returned
+
+            //Act
+            var result = xrmFakedContext.ExecuteCodeActivity<EmailBusinessUnitQueue>(workflowContext, inputs);
+
+            //Assert
+            Assert.AreEqual(expected, result["UsersAdded"]);
+        }
+
+        [TestMethod]
+        public void EmailBusinessUnitQueue_Business_Unit_With_Disabled_Queue()
+        {
+            //Arrange
+            XrmFakedWorkflowContext workflowContext = new XrmFakedWorkflowContext();
+
+            Guid id = Guid.NewGuid();
+            Entity email = new Entity("email")
+            {
+                Id = id,
+                ["activityid"] = id,
+                ["to"] = new EntityCollection()
+            };
+
+            Entity businessUnit = new Entity("businessunit")
+            {
+                Id = Guid.NewGuid()
+            };
+
+            Entity team = new Entity("team")
+            {
+                Id = Guid.NewGuid(),
+                ["isdefault"] = true,
+                ["businessunitid"] = businessUnit.Id
+            };
+
+            Entity systemUser1 = new Entity("systemuser")
+            {
+                Id = Guid.NewGuid(),
+                ["internalemailaddress"] = null,
+                ["isdisabled"] = false,
+                ["businessunitid"] = businessUnit.Id
+            };
+
+            Entity teammembership = new Entity("teammembership")
+            {
+                Id = Guid.NewGuid(),
+                ["teamid"] = team.Id,
+                ["systemuserid"] = systemUser1.Id
+            };
+
+            Entity queue = new Entity("queue")
+            {
+                Id = Guid.NewGuid(),
+                ["ownerid"] = team.Id,
+                ["owningteam"] = team.Id,
+                ["businessunitid"] = businessUnit.Id,
+                ["statecode"] = new OptionSetValue(1),
+                ["statuscode"] = new OptionSetValue(2)
+            };
+
+            // Relationship from team to its queue
+            team["queueid"] = queue.Id;
+
+            var inputs = new Dictionary<string, object>
+            {
+                { "EmailToSend", email.ToEntityReference() },
+                { "RecipientBusinessUnit", businessUnit.ToEntityReference() },
+                { "SendEmail", false }
+            };
+
+            XrmFakedContext xrmFakedContext = new XrmFakedContext();
+            xrmFakedContext.Initialize(new List<Entity> { email, businessUnit, team, systemUser1, teammembership, queue });
+
+            const int expected = 0;
+
+            //Act
+            var result = xrmFakedContext.ExecuteCodeActivity<EmailBusinessUnitQueue>(workflowContext, inputs);
+
+            //Assert
+            Assert.AreEqual(expected, result["UsersAdded"]);
+        }
+
+        [TestMethod]
+        public void EmailBusinessUnitQueue_1_Business_Unit_To_And_CC_With_Default_Teams_And_Queues()
+        {
+            //Arrange
+            XrmFakedWorkflowContext workflowContext = new XrmFakedWorkflowContext();
+
+            Guid idEmail = Guid.NewGuid();
+            Entity email = new Entity("email")
+            {
+                Id = idEmail,
+                ["activityid"] = idEmail,
+                ["cc"] = new EntityCollection()
+            };
+
+            // Existing recipient for To field
+            Guid idTo = Guid.NewGuid();
+            Entity activityPartyTo = new Entity("activityparty")
+            {
+                Id = idTo,
+                ["activitypartyid"] = idTo,
+                ["activityid"] = new EntityReference("email", idEmail),
+                ["partyid"] = new EntityReference("contact", Guid.NewGuid()),
+                ["participationtypemask"] = new OptionSetValue(2)
+            };
+
+            EntityCollection to = new EntityCollection();
+            to.Entities.Add(activityPartyTo);
+            email["to"] = to;
+
+            // Existing recipients for Cc field
+            Guid idCc1 = Guid.NewGuid();
+            Entity activityPartyCc1 = new Entity("activityparty")
+            {
+                Id = idCc1,
+                ["activitypartyid"] = idCc1,
+                ["activityid"] = new EntityReference("email", idEmail),
+                ["partyid"] = new EntityReference("contact", Guid.NewGuid()),
+                ["participationtypemask"] = new OptionSetValue(2)
+            };
+            Guid idCc2 = Guid.NewGuid();
+            Entity activityPartyCc2 = new Entity("activityparty")
+            {
+                Id = idCc1,
+                ["activitypartyid"] = idCc2,
+                ["activityid"] = new EntityReference("email", idEmail),
+                ["partyid"] = new EntityReference("contact", Guid.NewGuid()),
+                ["participationtypemask"] = new OptionSetValue(2)
+            };
+
+            EntityCollection cc = new EntityCollection();
+            cc.Entities.Add(activityPartyCc1);
+            cc.Entities.Add(activityPartyCc2);
+            email["cc"] = cc;
+
+            Entity businessUnit1 = new Entity("businessunit")
+            {
+                Id = Guid.NewGuid()
+            };
+
+            Entity team1 = new Entity("team")
+            {
+                Id = Guid.NewGuid(),
+                ["isdefault"] = true,
+                ["businessunitid"] = businessUnit1.Id
+            };
+
+            Entity systemUser1 = new Entity("systemuser")
+            {
+                Id = Guid.NewGuid(),
+                ["internalemailaddress"] = null,
+                ["isdisabled"] = false,
+                ["businessunitid"] = businessUnit1.Id
+            };
+
+            Entity teammembership1 = new Entity("teammembership")
+            {
+                Id = Guid.NewGuid(),
+                ["teamid"] = team1.Id,
+                ["systemuserid"] = systemUser1.Id
+            };
+
+            Entity queue1 = new Entity("queue")
+            {
+                Id = Guid.NewGuid(),
+                ["ownerid"] = team1.Id,
+                ["owningteam"] = team1.Id,
+                ["businessunitid"] = businessUnit1.Id
+            };
+
+            // Relationship from team to its queue
+            team1["queueid"] = queue1.Id;
+
+            EntityReference idInputEmail = email.ToEntityReference();
+            var inputsFirst = new Dictionary<string, object>
+            {
+                { "EmailToSend", idInputEmail },
+                { "RecipientBusinessUnit", businessUnit1.ToEntityReference() },
+                { "SendEmail", false }
+            };
+
+            var inputsSecond = new Dictionary<string, object>
+            {
+                { "EmailToSend", idInputEmail },
+                { "RecipientBusinessUnit", businessUnit1.ToEntityReference() },
+                { "SendEmail", false }
+            };
+
+            XrmFakedContext xrmFakedContext = new XrmFakedContext();
+            xrmFakedContext.Initialize(new List<Entity> { email, businessUnit1, team1, systemUser1, teammembership1, queue1, activityPartyTo, activityPartyCc1 });
+
+            const int expectedAfterTo = 2;
+            const int expectedAfterCc = 3;
+
+            //Act
+            var resultFirstAct = xrmFakedContext.ExecuteCodeActivity<EmailBusinessUnitQueue>(workflowContext, inputsFirst);
+
+            //Assert
+            Assert.AreEqual(expectedAfterTo, resultFirstAct["UsersAdded"]);
+
+            //Second Act
+            var resultSecondAct = xrmFakedContext.ExecuteCodeActivity<CcBusinessUnitQueue>(workflowContext, inputsSecond);
+
+            //Assert
+            Assert.AreEqual(expectedAfterCc, resultSecondAct["UsersAdded"]);
+        }
+
+        [TestMethod]
+        public void EmailBusinessUnitQueue_1_Business_Unit_To_1_Separate_BU_CC_With_Default_Teams_And_Queues()
+        {
+            //Arrange
+            XrmFakedWorkflowContext workflowContext = new XrmFakedWorkflowContext();
+
+            Guid idEmail = Guid.NewGuid();
+            Entity email = new Entity("email")
+            {
+                Id = idEmail,
+                ["activityid"] = idEmail,
+                ["cc"] = new EntityCollection()
+            };
+
+            // Existing recipient for To field
+            Guid idTo = Guid.NewGuid();
+            Entity activityPartyTo = new Entity("activityparty")
+            {
+                Id = idTo,
+                ["activitypartyid"] = idTo,
+                ["activityid"] = new EntityReference("email", idEmail),
+                ["partyid"] = new EntityReference("contact", Guid.NewGuid()),
+                ["participationtypemask"] = new OptionSetValue(2)
+            };
+
+            EntityCollection to = new EntityCollection();
+            to.Entities.Add(activityPartyTo);
+            email["to"] = to;
+
+            // Existing recipients for Cc field
+            Guid idCc1 = Guid.NewGuid();
+            Entity activityPartyCc1 = new Entity("activityparty")
+            {
+                Id = idCc1,
+                ["activitypartyid"] = idCc1,
+                ["activityid"] = new EntityReference("email", idEmail),
+                ["partyid"] = new EntityReference("contact", Guid.NewGuid()),
+                ["participationtypemask"] = new OptionSetValue(2)
+            };
+            Guid idCc2 = Guid.NewGuid();
+            Entity activityPartyCc2 = new Entity("activityparty")
+            {
+                Id = idCc1,
+                ["activitypartyid"] = idCc2,
+                ["activityid"] = new EntityReference("email", idEmail),
+                ["partyid"] = new EntityReference("contact", Guid.NewGuid()),
+                ["participationtypemask"] = new OptionSetValue(2)
+            };
+
+            EntityCollection cc = new EntityCollection();
+            cc.Entities.Add(activityPartyCc1);
+            cc.Entities.Add(activityPartyCc2);
+            email["cc"] = cc;
+
+            // First BU
+            Entity businessUnit1 = new Entity("businessunit")
+            {
+                Id = Guid.NewGuid()
+            };
+
+            Entity team1 = new Entity("team")
+            {
+                Id = Guid.NewGuid(),
+                ["isdefault"] = true,
+                ["businessunitid"] = businessUnit1.Id
+            };
+
+            Entity systemUser1 = new Entity("systemuser")
+            {
+                Id = Guid.NewGuid(),
+                ["internalemailaddress"] = null,
+                ["isdisabled"] = false,
+                ["businessunitid"] = businessUnit1.Id
+            };
+
+            Entity teammembership1 = new Entity("teammembership")
+            {
+                Id = Guid.NewGuid(),
+                ["teamid"] = team1.Id,
+                ["systemuserid"] = systemUser1.Id
+            };
+
+            Entity queue1 = new Entity("queue")
+            {
+                Id = Guid.NewGuid(),
+                ["ownerid"] = team1.Id,
+                ["owningteam"] = team1.Id,
+                ["businessunitid"] = businessUnit1.Id
+            };
+
+            // Relationship from team to its queue
+            team1["queueid"] = queue1.Id;
+
+            // Second BU
+            Entity businessUnit2 = new Entity("businessunit")
+            {
+                Id = Guid.NewGuid()
+            };
+
+            Entity team2 = new Entity("team")
+            {
+                Id = Guid.NewGuid(),
+                ["isdefault"] = true,
+                ["businessunitid"] = businessUnit2.Id
+            };
+
+            Entity systemUser2 = new Entity("systemuser")
+            {
+                Id = Guid.NewGuid(),
+                ["internalemailaddress"] = null,
+                ["isdisabled"] = false,
+                ["businessunitid"] = businessUnit2.Id
+            };
+
+            Entity teammembership2 = new Entity("teammembership")
+            {
+                Id = Guid.NewGuid(),
+                ["teamid"] = team2.Id,
+                ["systemuserid"] = systemUser2.Id
+            };
+
+            Entity queue2 = new Entity("queue")
+            {
+                Id = Guid.NewGuid(),
+                ["ownerid"] = team2.Id,
+                ["owningteam"] = team2.Id,
+                ["businessunitid"] = businessUnit2.Id
+            };
+
+            // Relationship from team to its queue
+            team2["queueid"] = queue2.Id;
+
+            EntityReference idInputEmail = email.ToEntityReference();
+            var inputsFirst = new Dictionary<string, object>
+            {
+                { "EmailToSend", idInputEmail },
+                { "RecipientBusinessUnit", businessUnit1.ToEntityReference() },
+                { "SendEmail", false }
+            };
+
+            var inputsSecond = new Dictionary<string, object>
+            {
+                { "EmailToSend", idInputEmail },
+                { "RecipientBusinessUnit", businessUnit2.ToEntityReference() },
+                { "SendEmail", false }
+            };
+
+            XrmFakedContext xrmFakedContext = new XrmFakedContext();
+            xrmFakedContext.Initialize(new List<Entity> { email, businessUnit1, team1, systemUser1, teammembership1, queue1, businessUnit2, team2, systemUser2, teammembership2, queue2, activityPartyTo, activityPartyCc1 });
+
+            const int expectedAfterTo = 2;
+            const int expectedAfterCc = 3;
+
+            //Act
+            var resultFirstAct = xrmFakedContext.ExecuteCodeActivity<EmailBusinessUnitQueue>(workflowContext, inputsFirst);
+
+            //Assert
+            Assert.AreEqual(expectedAfterTo, resultFirstAct["UsersAdded"]);
+
+            //Second Act
+            var resultSecondAct = xrmFakedContext.ExecuteCodeActivity<CcBusinessUnitQueue>(workflowContext, inputsSecond);
+
+            //Assert
+            Assert.AreEqual(expectedAfterCc, resultSecondAct["UsersAdded"]);
+        }
+    }
+}

--- a/LAT.WorkflowUtilities.Email.Tests/LAT.WorkflowUtilities.Email.Tests.csproj
+++ b/LAT.WorkflowUtilities.Email.Tests/LAT.WorkflowUtilities.Email.Tests.csproj
@@ -95,6 +95,7 @@
     <Compile Include="CreateTemplateTests.cs" />
     <Compile Include="CheckAttachmentsTests.cs" />
     <Compile Include="DeleteAttachmentByNameTests.cs" />
+    <Compile Include="EmailBusinessUnitQueueTests.cs" />
     <Compile Include="EmailBusinessUnitTests.cs" />
     <Compile Include="EmailQueueMembersTests.cs" />
     <Compile Include="EmailSecurityRoleTests.cs" />

--- a/LAT.WorkflowUtilities.Email/CcBusinessUnitQueue.cs
+++ b/LAT.WorkflowUtilities.Email/CcBusinessUnitQueue.cs
@@ -55,7 +55,7 @@ namespace LAT.WorkflowUtilities.Email
             }
 
             //Add any pre-defined recipients specified to the array               
-            foreach (Entity activityParty in email.GetAttributeValue<EntityCollection>("to").Entities)
+            foreach (Entity activityParty in email.GetAttributeValue<EntityCollection>("cc").Entities)
             {
                 ccList.Add(activityParty);
             }
@@ -64,20 +64,21 @@ namespace LAT.WorkflowUtilities.Email
 
             if (buQueues.Entities.Count < 1)
             {
-                EmailSent.Set(context, false);
                 localContext.Trace("GetBuQueue found no default queues for the Business Unit.");
-                return;
             }
-            else if (buQueues.Entities.Count > 1)
+            else
             {
-                localContext.Trace("GetBuQueue found more than one default queue for the Business Unit.");
+                if (buQueues.Entities.Count > 1)
+                {
+                    localContext.Trace("GetBuQueue found more than one default queue for the Business Unit.");
+                }
+
+                ccList = ProcessQueues(buQueues, ccList);
+
+                //Update the email
+                email["cc"] = ccList.ToArray();
+                localContext.OrganizationService.Update(email);
             }
-
-            ccList = ProcessQueues(buQueues, ccList);
-
-            //Update the email
-            email["cc"] = ccList.ToArray();
-            localContext.OrganizationService.Update(email);
 
             //Send
             if (sendEmail)

--- a/LAT.WorkflowUtilities.Email/CcBusinessUnitQueue.cs
+++ b/LAT.WorkflowUtilities.Email/CcBusinessUnitQueue.cs
@@ -33,6 +33,9 @@ namespace LAT.WorkflowUtilities.Email
         [Output("Email Sent")]
         public OutArgument<bool> EmailSent { get; set; }
 
+        [Output("Users Added")]
+        public OutArgument<int> UsersAdded { get; set; }
+
         protected override void ExecuteCrmWorkFlowActivity(CodeActivityContext context, LocalWorkflowContext localContext)
         {
             if (context == null)
@@ -51,6 +54,7 @@ namespace LAT.WorkflowUtilities.Email
             if (email == null)
             {
                 EmailSent.Set(context, false);
+                UsersAdded.Set(context, 0);
                 return;
             }
 
@@ -97,6 +101,8 @@ namespace LAT.WorkflowUtilities.Email
             {
                 EmailSent.Set(context, false);
             }
+
+            UsersAdded.Set(context, ccList.Count);
         }
 
         private static Entity RetrieveEmail(IOrganizationService service, Guid emailId)
@@ -152,6 +158,18 @@ namespace LAT.WorkflowUtilities.Email
                         LinkToEntityName = "team",
                         LinkToAttributeName = "queueid",
                         LinkCriteria = filter
+                    }
+                },
+                Criteria = new FilterExpression
+                {
+                    Conditions =
+                    {
+                        new ConditionExpression
+                        {
+                            AttributeName = "statecode",
+                            Operator = ConditionOperator.Equal,
+                            Values = { 0 }
+                        }
                     }
                 }
             };

--- a/LAT.WorkflowUtilities.Email/EmailBusinessUnitQueue.cs
+++ b/LAT.WorkflowUtilities.Email/EmailBusinessUnitQueue.cs
@@ -1,0 +1,179 @@
+﻿using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using Microsoft.Xrm.Sdk.Workflow;
+using System;
+using System.Activities;
+using System.Collections.Generic;
+using System.Linq;
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+// ReSharper disable MemberCanBePrivate.Global
+
+namespace LAT.WorkflowUtilities.Email
+{
+    public class EmailBusinessUnitQueue : WorkFlowActivityBase
+    {
+        public EmailBusinessUnitQueue() : base(typeof(EmailBusinessUnitQueue)) { }
+
+        [RequiredArgument]
+        [Input("Email To Send")]
+        [ReferenceTarget("email")]
+        public InArgument<EntityReference> EmailToSend { get; set; }
+
+        [RequiredArgument]
+        [Input("Recipient Business Unit")]
+        [ReferenceTarget("businessunit")]
+        public InArgument<EntityReference> RecipientBusinessUnit { get; set; }
+
+        [RequiredArgument]
+        [Default("false")]
+        [Input("Send Email?")]
+        public InArgument<bool> SendEmail { get; set; }
+
+        [Output("Email Sent")]
+        public OutArgument<bool> EmailSent { get; set; }
+
+        protected override void ExecuteCrmWorkFlowActivity(CodeActivityContext context, LocalWorkflowContext localContext)
+        {
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
+            if (localContext == null)
+                throw new ArgumentNullException(nameof(localContext));
+
+            EntityReference emailToSend = EmailToSend.Get(context);
+            EntityReference recipientBusinessUnit = RecipientBusinessUnit.Get(context);
+            bool sendEmail = SendEmail.Get(context);
+
+            List<Entity> toList = new List<Entity>();
+
+            Entity email = RetrieveEmail(localContext.OrganizationService, emailToSend.Id);
+
+            if (email == null)
+            {
+                EmailSent.Set(context, false);
+                return;
+            }
+
+            //Add any pre-defined recipients specified to the array               
+            foreach (Entity activityParty in email.GetAttributeValue<EntityCollection>("to").Entities)
+            {
+                toList.Add(activityParty);
+            }
+
+            List<EntityReference> buQueues = GetBuQueues(localContext.OrganizationService, recipientBusinessUnit.Id);
+
+            if (buQueues.Count < 1)
+            {
+                EmailSent.Set(context, false);
+                localContext.Trace("GetBuQueue found no default queues for the Business Unit.");
+                return;
+            }
+            else if (buQueues.Count > 1)
+            {
+                localContext.Trace("GetBuQueue found more than one default queue for the Business Unit.");
+            }
+
+            toList = ProcessQueues(buQueues, toList);
+
+            //Update the email
+            email["to"] = toList.ToArray();
+            localContext.OrganizationService.Update(email);
+
+            //Send
+            if (sendEmail)
+            {
+                SendEmailRequest request = new SendEmailRequest
+                {
+                    EmailId = emailToSend.Id,
+                    TrackingToken = string.Empty,
+                    IssueSend = true
+                };
+
+                localContext.OrganizationService.Execute(request);
+                EmailSent.Set(context, true);
+            }
+            else
+            {
+                EmailSent.Set(context, false);
+            }
+        }
+
+        private static Entity RetrieveEmail(IOrganizationService service, Guid emailId)
+        {
+            return service.Retrieve("email", emailId, new ColumnSet("to"));
+        }
+
+        private static List<Entity> ProcessQueues(List<EntityReference> queues, List<Entity> toList)
+        {
+            foreach (EntityReference e in queues)
+            {
+                Entity activityParty =
+                    new Entity("activityparty")
+                    {
+                        ["partyid"] = e
+                    };
+
+                if (toList.Any(t => t.GetAttributeValue<EntityReference>("partyid").Id == e.Id)) continue;
+
+                toList.Add(activityParty);
+            }
+
+            return toList;
+        }
+
+        private static List<EntityReference> GetBuQueues(IOrganizationService service, Guid businessUnitId)
+        {
+            //Query for the business unit members
+            QueryExpression query = new QueryExpression
+            {
+                EntityName = "team",
+                ColumnSet = new ColumnSet("queueid"),
+                LinkEntities =
+                {
+                    new LinkEntity
+                    {
+                        LinkFromEntityName = "team",
+                        LinkFromAttributeName = "businessunitid",
+                        LinkToEntityName = "businessunit",
+                        LinkToAttributeName = "businessunitid",
+                        LinkCriteria = new FilterExpression
+                        {
+                            FilterOperator = LogicalOperator.And,
+                            Conditions =
+                            {
+                                new ConditionExpression
+                                {
+                                    AttributeName = "businessunitid",
+                                    Operator = ConditionOperator.Equal,
+                                    Values = { businessUnitId }
+                                }
+                            }
+                        }
+                    }
+                },
+                Criteria = new FilterExpression
+                {
+                    Conditions =
+                    {
+                        new ConditionExpression
+                        {
+                            AttributeName = "isdefault",
+                            Operator = ConditionOperator.Equal,
+                            Values = { false }
+                        }
+                    }
+                }
+            };
+
+            EntityCollection results = service.RetrieveMultiple(query);
+            List<EntityReference> queues = new List<EntityReference>();
+
+            foreach (Entity t in results.Entities)
+            {
+                queues.Add((EntityReference)t["queueid"]);
+            }
+
+            return queues;
+        }
+    }
+}

--- a/LAT.WorkflowUtilities.Email/EmailBusinessUnitQueue.cs
+++ b/LAT.WorkflowUtilities.Email/EmailBusinessUnitQueue.cs
@@ -64,20 +64,21 @@ namespace LAT.WorkflowUtilities.Email
 
             if (buQueues.Entities.Count < 1)
             {
-                EmailSent.Set(context, false);
                 localContext.Trace("GetBuQueue found no default queues for the Business Unit.");
-                return;
             }
-            else if (buQueues.Entities.Count > 1)
+            else
             {
-                localContext.Trace("GetBuQueue found more than one default queue for the Business Unit.");
+                if (buQueues.Entities.Count > 1)
+                {
+                    localContext.Trace("GetBuQueue found more than one default queue for the Business Unit.");
+                }
+
+                toList = ProcessQueues(buQueues, toList);
+
+                //Update the email
+                email["to"] = toList.ToArray();
+                localContext.OrganizationService.Update(email);
             }
-
-            toList = ProcessQueues(buQueues, toList);
-
-            //Update the email
-            email["to"] = toList.ToArray();
-            localContext.OrganizationService.Update(email);
 
             //Send
             if (sendEmail)

--- a/LAT.WorkflowUtilities.Email/EmailBusinessUnitQueue.cs
+++ b/LAT.WorkflowUtilities.Email/EmailBusinessUnitQueue.cs
@@ -33,6 +33,9 @@ namespace LAT.WorkflowUtilities.Email
         [Output("Email Sent")]
         public OutArgument<bool> EmailSent { get; set; }
 
+        [Output("Users Added")]
+        public OutArgument<int> UsersAdded { get; set; }
+
         protected override void ExecuteCrmWorkFlowActivity(CodeActivityContext context, LocalWorkflowContext localContext)
         {
             if (context == null)
@@ -51,6 +54,7 @@ namespace LAT.WorkflowUtilities.Email
             if (email == null)
             {
                 EmailSent.Set(context, false);
+                UsersAdded.Set(context, 0);
                 return;
             }
 
@@ -97,6 +101,8 @@ namespace LAT.WorkflowUtilities.Email
             {
                 EmailSent.Set(context, false);
             }
+
+            UsersAdded.Set(context, toList.Count);
         }
 
         private static Entity RetrieveEmail(IOrganizationService service, Guid emailId)
@@ -152,6 +158,18 @@ namespace LAT.WorkflowUtilities.Email
                         LinkToEntityName = "team",
                         LinkToAttributeName = "queueid",
                         LinkCriteria = filter
+                    }
+                },
+                Criteria = new FilterExpression
+                {
+                    Conditions =
+                    {
+                        new ConditionExpression
+                        {
+                            AttributeName = "statecode",
+                            Operator = ConditionOperator.Equal,
+                            Values = { 0 }
+                        }
                     }
                 }
             };

--- a/LAT.WorkflowUtilities.Email/LAT.WorkflowUtilities.Email.csproj
+++ b/LAT.WorkflowUtilities.Email/LAT.WorkflowUtilities.Email.csproj
@@ -74,6 +74,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CcBusinessUnit.cs" />
+    <Compile Include="CcBusinessUnitQueue.cs" />
     <Compile Include="CreateTemplate.cs" />
     <Compile Include="DeleteAttachmentByName.cs" />
     <Compile Include="DynamicUrlParser.cs" />

--- a/LAT.WorkflowUtilities.Email/LAT.WorkflowUtilities.Email.csproj
+++ b/LAT.WorkflowUtilities.Email/LAT.WorkflowUtilities.Email.csproj
@@ -81,6 +81,7 @@
     <Compile Include="CcSecurityRole.cs" />
     <Compile Include="CcQueueMembers.cs" />
     <Compile Include="CcConnection.cs" />
+    <Compile Include="EmailBusinessUnitQueue.cs" />
     <Compile Include="EmailQueueMembers.cs" />
     <Compile Include="EmailConnection.cs" />
     <Compile Include="EmailSecurityRole.cs" />

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Custom workflow actions that deal with emails in Dynamics CRM 2015, 2016, & D365
 * CC Queue Members
 * Email Connection 
 * CC Connection 
+* Email Business Unit's default queue
+* CC Business Unit's default queue
 * Delete Email Attachments
 * Delete Email Attachments By Name
 * Send Draft Email


### PR DESCRIPTION
Hi,

On a recent project we received a requirement for SLA notifications to be emailed to the default queues of the business unit, of the team or user that created, a case and the team or user that has it assigned. Microsoft Support, when we queried about this, replied that this is not an out-of-the-box functionality, but pointed us to your plugin.

We found that it was almost what we neeeded, but not quite. So, I took on the task to code the additions needed. Tried to keep your style as much as I understood it, and to include tests.

This code is on production now, but given COVID-19, a Go Live with the complete roll out of features has been postponed. I can say that we tested with emails and several case combinations, so I'm confident the code is ok, even though I would feel more secure about it not having any bugs after widespread usage. If any issues show up, I will also fix them and let you know.

I hope you find this code useful, as we have found yours. Thank you for sharing it.

Regards, I hope all is well with you during these times,

Luciano.-